### PR TITLE
refactor : 유저 인덱스 초기화 방식 변경

### DIFF
--- a/src/test/java/com/example/team1_be/domain/User/UserRepositoryTest.java
+++ b/src/test/java/com/example/team1_be/domain/User/UserRepositoryTest.java
@@ -22,8 +22,8 @@ class UserRepositoryTest {
     public void resetRepository() {
         em.clear();
         userRepository.deleteAll();
-        em.createNativeQuery("TRUNCATE TABLE User_tb RESTART IDENTITY;")
-                        .executeUpdate();
+        em.createNativeQuery("ALTER TABLE User_tb ALTER COLUMN `user_id` RESTART WITH 1")
+                .executeUpdate();
         em.clear();
     }
 


### PR DESCRIPTION
기존 방식의 초기화는 다른 리포지토리와 같이 동작하면 에러가 발생함
그래서 단순하게 id를 1로 시작한다 라는 설정으로 초기화
실제 초기화의 의미는 아님