### PR TITLE
월별 멤버 확정 스케줄 조회 서비스 분리

### DIFF
--- a/src/main/java/com/example/team1_be/domain/Schedule/ScheduleController.java
+++ b/src/main/java/com/example/team1_be/domain/Schedule/ScheduleController.java
@@ -69,4 +69,12 @@ public class ScheduleController {
         ApiUtils.ApiResult<Object> response = ApiUtils.success(responseDTO);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/fix/month/{requestMonth}")
+    public ResponseEntity<?> getUsersFixedWeeklySchedule(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                    @PathVariable("requestMonth") @DateTimeFormat(pattern = "yyyy-MM") YearMonth requestMonth) {
+        GetFixedWeeklySchedule.Response responseDTO =  scheduleService.getUsersFixedWeeklySchedule(userDetails.getUser(), requestMonth);
+        ApiUtils.ApiResult<?> response = ApiUtils.success(responseDTO);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/test/java/com/example/team1_be/domain/Schedule/GetUsersFixedWeeklySchedule.java
+++ b/src/test/java/com/example/team1_be/domain/Schedule/GetUsersFixedWeeklySchedule.java
@@ -1,0 +1,50 @@
+package com.example.team1_be.domain.Schedule;
+
+
+import com.example.team1_be.util.WithMockCustomUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.YearMonth;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Sql("/data.sql")
+public class GetUsersFixedWeeklySchedule {
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ObjectMapper om;
+
+    @DisplayName("개인 확정 스케줄 조회 성공")
+    @WithMockCustomUser(userId = "2")
+    @Test
+    void GetUsersFixedWeeklySchedule1() throws Exception {
+        YearMonth month = YearMonth.parse("2023-10");
+        ResultActions perform = mvc.perform(
+                get(String.format("/schedule/fix/month/%s", month)));
+        perform.andExpect(status().isOk());
+        perform.andDo(print());
+    }
+
+    @DisplayName("개인 확정 스케줄 조회 실패(파라미터 에러)")
+    @WithMockCustomUser(userId = "2")
+    @Test
+    void GetUsersFixedWeeklySchedule2() throws Exception {
+        ResultActions perform = mvc.perform(
+                get(String.format("/schedule/fix/month/%s", "2023")));
+        perform.andExpect(status().isBadRequest());
+        perform.andDo(print());
+    }
+}

--- a/src/test/java/com/example/team1_be/domain/Schedule/ScheduleControllerTest.java
+++ b/src/test/java/com/example/team1_be/domain/Schedule/ScheduleControllerTest.java
@@ -279,8 +279,8 @@ class ScheduleControllerTest {
         perform.andDo(print());
     }
 
-    @DisplayName("확정 스케줄 조회 성공")
-    @WithMockCustomUser(userId = "2")
+    @DisplayName("멤버별 확정 스케줄 조회 성공")
+    @WithMockCustomUser
     @Test
     void getFixedWeeklySchedule1() throws Exception {
         YearMonth month = YearMonth.parse("2023-10");
@@ -291,8 +291,8 @@ class ScheduleControllerTest {
         perform.andDo(print());
     }
 
-    @DisplayName("확정 스케줄 조회 실패(파라미터 에러)")
-    @WithMockCustomUser(userId = "2")
+    @DisplayName("멤버별 확정 스케줄 조회 실패(파라미터 에러)")
+    @WithMockCustomUser
     @Test
     void getFixedWeeklySchedule2() throws Exception {
         Long memberId = 2L;


### PR DESCRIPTION
# 변경 사항 요약

멤버 자신의 스케줄을 확인할 수 있는 기능 분리

## 변경 사항 상세내역

1. 기존 확정 스케줄조회는 매니저가 멤버스케줄 확인용이므로 분리
2. 멤버만해당 요청 가입가능

## 사용 방법

get : /schedule/fix/month/{requestMonth} 요청

## 관련 이슈

close #183 

## 테스트 계획 및 결과

1. 기존 요청과 동일하되 mockuser 변경

## 부가 정보 및 주의사항

PR과 관련하여 추가적으로 알려줘야 할 사항이나 주의할 점 등이 있다면 여기에 적으세요.

# PR 체크리스트
아래 요구사항을 만족하는 지 확인해주세요:

- [x] 요청 직전에 weekly 브랜치의 최신 상태가 반영되었는가
- [x] 실행시 에러가 발생하지 않는가
- [x] 변경 사항에 대한 테스트 코드가 추가되었는가 (버그 수정 / 기능 추가)
- [ ] 문서 업데이트 작업이 수행되었는가 (버그 수정 / 기능 추가)

# PR 유형
본 PR은 어떠한 변화를 가져오나요?

<!-- "x" 로 해당하는 항목을 선택하세요. -->

- [ ] 버그 수정
- [x] 신규 기능 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 스타일 업데이트 (형식화, 로컬 변수)
- [ ] 빌드 관련 변화 
- [ ] 환경설정 관련 변화 
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타... 설명해주세요: