### PR TITLE
주별 상태 조회 API 구현

### DIFF
--- a/src/main/java/com/example/team1_be/domain/Schedule/DTO/GetWeekStatus.java
+++ b/src/main/java/com/example/team1_be/domain/Schedule/DTO/GetWeekStatus.java
@@ -1,0 +1,23 @@
+package com.example.team1_be.domain.Schedule.DTO;
+
+import com.example.team1_be.domain.Week.WeekRecruitmentStatus;
+import lombok.Getter;
+
+public class GetWeekStatus {
+    @Getter
+    public static class Response {
+        private String weekStatus;
+
+        public Response(WeekRecruitmentStatus status) {
+            if (status == null) {
+                this.weekStatus = "allocatable";
+            }
+            if (status == WeekRecruitmentStatus.STARTED) {
+                this.weekStatus = "inProgress";
+            }
+            if (status == WeekRecruitmentStatus.ENDED) {
+                this.weekStatus = "closed";
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/team1_be/domain/Schedule/ScheduleController.java
+++ b/src/main/java/com/example/team1_be/domain/Schedule/ScheduleController.java
@@ -85,4 +85,12 @@ public class ScheduleController {
         ApiUtils.ApiResult<?> response = ApiUtils.success(responseDTO);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/status/{startWeekDate}")
+    public ResponseEntity<?> getWeekStatus(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                           @PathVariable("startWeekDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startWeekDate) {
+        GetWeekStatus.Response responseDTO = scheduleService.getWeekStatus(userDetails.getUser(), startWeekDate);
+        ApiUtils.ApiResult<GetWeekStatus.Response> response = ApiUtils.success(responseDTO);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/team1_be/domain/Week/WeekRepository.java
+++ b/src/main/java/com/example/team1_be/domain/Week/WeekRepository.java
@@ -1,6 +1,5 @@
 package com.example.team1_be.domain.Week;
 
-import com.example.team1_be.domain.Schedule.Schedule;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,7 +17,7 @@ public interface WeekRepository extends JpaRepository<Week, Long> {
             "where w.schedule.id = :scheduleId" +
             " and w.startDate = :startDate " +
             "and w.status = :status")
-    Optional<Week> findByScheduleIdStartDateAndAndStatus(@Param("scheduleId") Long scheduleId, @Param("startDate")LocalDate startDate, @Param("status") WeekRecruitmentStatus status);
+    Optional<Week> findByScheduleIdStartDateAndStatus(@Param("scheduleId") Long scheduleId, @Param("startDate")LocalDate startDate, @Param("status") WeekRecruitmentStatus status);
 
     @Query("select w " +
             "from Week w " +
@@ -35,7 +34,14 @@ public interface WeekRepository extends JpaRepository<Week, Long> {
             "where w.schedule.id = :scheduleId " +
             "and w.status = :weekStatus " +
             "order by w.id desc")
-    Page<Week> findByScheduleAndStatus(@Param("scheduleId") Long id,
-                                       @Param("weekStatus") WeekRecruitmentStatus weekRecruitmentStatus,
-                                       Pageable pageable);
+    Page<Week> findLatestByScheduleAndStatus(@Param("scheduleId") Long id,
+                                             @Param("weekStatus") WeekRecruitmentStatus weekRecruitmentStatus,
+                                             Pageable pageable);
+
+    @Query("select w " +
+            "from Week w " +
+            "where w.schedule.id = :scheduleId " +
+            "and w.startDate = :startDate")
+    Optional<Week> findByScheduleIdAndStartDate(@Param("scheduleId") Long id,
+                                       @Param("startDate") LocalDate startDate);
 }

--- a/src/test/java/com/example/team1_be/domain/Schedule/GetWeekStatus.java
+++ b/src/test/java/com/example/team1_be/domain/Schedule/GetWeekStatus.java
@@ -1,0 +1,76 @@
+package com.example.team1_be.domain.Schedule;
+
+import com.example.team1_be.util.WithMockCustomUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Sql("/data.sql")
+public class GetWeekStatus {
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ObjectMapper om;
+
+    @DisplayName("주별 상태 조회 closed")
+    @WithMockCustomUser
+    @Test
+    void getWeekStatus1() throws Exception {
+        // given
+        LocalDate startDate = LocalDate.parse("2023-10-09");
+
+        // when
+        ResultActions perform = mvc.perform(
+                get(String.format("/schedule/status/%s", startDate)));
+
+        // then
+        perform.andExpect(status().isOk());
+        perform.andDo(print());
+    }
+
+    @DisplayName("주별 상태 조회 inProgress")
+    @WithMockCustomUser
+    @Test
+    void getWeekStatus2() throws Exception {
+        // given
+        LocalDate startDate = LocalDate.parse("2023-10-16");
+
+        // when
+        ResultActions perform = mvc.perform(
+                get(String.format("/schedule/status/%s", startDate)));
+
+        // then
+        perform.andExpect(status().isOk());
+        perform.andDo(print());
+    }
+
+    @DisplayName("주별 상태 조회 allocatable")
+    @WithMockCustomUser
+    @Test
+    void getWeekStatus3() throws Exception {
+        // given
+        LocalDate startDate = LocalDate.parse("2023-10-23");
+
+        // when
+        ResultActions perform = mvc.perform(
+                get(String.format("/schedule/status/%s", startDate)));
+
+        // then
+        perform.andExpect(status().isOk());
+        perform.andDo(print());
+    }
+}

--- a/src/test/java/com/example/team1_be/domain/Schedule/Repository/ScheduleRepositoryTest.java
+++ b/src/test/java/com/example/team1_be/domain/Schedule/Repository/ScheduleRepositoryTest.java
@@ -3,7 +3,6 @@ package com.example.team1_be.domain.Schedule.Repository;
 import com.example.team1_be.BaseTest;
 import com.example.team1_be.domain.Apply.ApplyRepository;
 import com.example.team1_be.domain.Day.DayRepository;
-import com.example.team1_be.domain.Group.Group;
 import com.example.team1_be.domain.Group.GroupRepository;
 import com.example.team1_be.domain.Member.MemberRepository;
 import com.example.team1_be.domain.Notification.NotificationRepository;
@@ -17,13 +16,15 @@ import com.example.team1_be.domain.Week.WeekRepository;
 import com.example.team1_be.domain.Worktime.WorktimeRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 import javax.persistence.EntityManager;
 
 
+import java.time.LocalDate;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class ScheduleRepositoryTest extends BaseTest {
 
@@ -42,7 +43,7 @@ class ScheduleRepositoryTest extends BaseTest {
     @Test
     void test2() {
         Schedule schedule = scheduleRepository.findById(1L).orElse(null);
-        Week lastestWeek = weekRepository.findByScheduleAndStatus(schedule.getId(),
+        Week lastestWeek = weekRepository.findLatestByScheduleAndStatus(schedule.getId(),
                 WeekRecruitmentStatus.ENDED,
                 PageRequest.of(0, 1)).getContent().get(0);
         assertThat(lastestWeek).isNotEqualTo(null);
@@ -51,5 +52,15 @@ class ScheduleRepositoryTest extends BaseTest {
                 .stream()
                 .forEach(x->System.out.println(x.getTitle()));
 
+    }
+
+    @DisplayName("주별 상태 조회")
+    @Test
+    void test3() {
+        LocalDate startDate = LocalDate.parse("2023-10-09");
+        Schedule schedule = scheduleRepository.findById(1L).orElse(null);
+        Week week = weekRepository.findByScheduleIdAndStartDate(schedule.getId(), startDate).orElse(null);
+        assertThat(week).isNotEqualTo(null);
+        System.out.println(week.getStatus());
     }
 }

--- a/src/test/java/com/example/team1_be/domain/Week/WeekRepositoryTest.java
+++ b/src/test/java/com/example/team1_be/domain/Week/WeekRepositoryTest.java
@@ -39,14 +39,14 @@ class WeekRepositoryTest extends BaseTest {
     @DisplayName("시작일, 스케줄, 상태 기반 조회 성공")
     @Test
     void test2() {
-        assertThat(weekRepository.findByScheduleIdStartDateAndAndStatus(1L, LocalDate.parse("2023-10-09"), ENDED)
+        assertThat(weekRepository.findByScheduleIdStartDateAndStatus(1L, LocalDate.parse("2023-10-09"), ENDED)
                 .orElse(null)).isNotEqualTo(null);
     }
 
     @DisplayName("시작일, 스케줄, 상태 기반 조회 실패")
     @Test
     void test3() {
-        assertThat(weekRepository.findByScheduleIdStartDateAndAndStatus(1L, LocalDate.parse("2023-10-09"), STARTED)
+        assertThat(weekRepository.findByScheduleIdStartDateAndStatus(1L, LocalDate.parse("2023-10-09"), STARTED)
                 .orElse(null)).isEqualTo(null);
     }
 }


### PR DESCRIPTION
# 변경 사항 요약

스케줄에서 확인하려는 주의 상태를 확인(모집가능, 모집중, 모집완료)

## 변경 사항 상세내역

모집가능에 대해서는 엔티티에 상태가 존재하지 않으므로 week가 조회되지 않을 경우 모집가능(allocatable)상태가 응답됨

## 사용 방법

스케줄상의 특정날짜를 입력하면 해당 주차의 시작일을 BE로 전송하여 처리한다.

## 관련 이슈

close #186 
close #103 

## 테스트 계획 및 결과

- 주별 상태 조회 closed
- 주별 상태 조회 inProgress
- 주별 상태 조회 allocatable
- 주별 상태 조회(repository)

## 부가 정보 및 주의사항

PR과 관련하여 추가적으로 알려줘야 할 사항이나 주의할 점 등이 있다면 여기에 적으세요.

# PR 체크리스트
아래 요구사항을 만족하는 지 확인해주세요:

- [x] 요청 직전에 weekly 브랜치의 최신 상태가 반영되었는가
- [x] 실행시 에러가 발생하지 않는가
- [x] 변경 사항에 대한 테스트 코드가 추가되었는가 (버그 수정 / 기능 추가)
- [ ] 문서 업데이트 작업이 수행되었는가 (버그 수정 / 기능 추가)

# PR 유형
본 PR은 어떠한 변화를 가져오나요?

<!-- "x" 로 해당하는 항목을 선택하세요. -->

- [ ] 버그 수정
- [ ] 신규 기능 
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 스타일 업데이트 (형식화, 로컬 변수)
- [ ] 빌드 관련 변화 
- [ ] 환경설정 관련 변화 
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타... 설명해주세요: