### PR TITLE
Security 인증/인가 엔트리 포인트

### DIFF
--- a/src/main/java/com/example/team1_be/utils/security/AuthenticationConfig.java
+++ b/src/main/java/com/example/team1_be/utils/security/AuthenticationConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 
 import com.example.team1_be.utils.security.XSS.XSSProtectFilter;
+import com.example.team1_be.utils.security.auth.CustomAccessDeniedHandler;
+import com.example.team1_be.utils.security.auth.CustomAuthenticationEntryPoint;
 import com.example.team1_be.utils.security.auth.jwt.JwtAuthenticationFilter;
 import com.example.team1_be.utils.security.auth.jwt.JwtProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,6 +57,12 @@ public class AuthenticationConfig {
 
 		http.sessionManagement()
 			.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+		http.exceptionHandling()
+			.authenticationEntryPoint(new CustomAuthenticationEntryPoint(om));
+
+		http.exceptionHandling()
+			.accessDeniedHandler(new CustomAccessDeniedHandler(om));
 
 		http.authorizeHttpRequests()
 			.antMatchers("/h2-console/**").permitAll()

--- a/src/main/java/com/example/team1_be/utils/security/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/team1_be/utils/security/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.example.team1_be.utils.security.auth;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import com.example.team1_be.utils.ApiUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+	private final ObjectMapper om;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		ApiUtils.ApiError apiError = new ApiUtils.ApiError("유효하지 않은 인증입니다.", -21000);
+		ApiUtils.ApiResult apiResult = new ApiUtils.ApiResult(false, null, apiError);
+
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType("application/json");
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.getWriter().write(om.writeValueAsString(apiResult));
+	}
+}

--- a/src/main/java/com/example/team1_be/utils/security/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/team1_be/utils/security/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.example.team1_be.utils.security.auth;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.example.team1_be.utils.ApiUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	private final ObjectMapper om;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		ApiUtils.ApiError apiError = new ApiUtils.ApiError("유효하지 않은 인증입니다.", -21000);
+		ApiUtils.ApiResult apiResult = new ApiUtils.ApiResult(false, null, apiError);
+
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType("application/json");
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.getWriter().write(om.writeValueAsString(apiResult));
+	}
+}

--- a/src/test/java/com/example/team1_be/domain/Group/GroupControllerTest.java
+++ b/src/test/java/com/example/team1_be/domain/Group/GroupControllerTest.java
@@ -120,7 +120,7 @@ public class GroupControllerTest {
 	}
 
 	@DisplayName("그룹 초대장 제출 실패(초대장 갱신시점이 없음)")
-	@WithMockCustomAdminUser(username = "dksgkswn", userId = "2", kakaoId = "2")
+	@WithMockCustomMemberUser(username = "dksgkswn", userId = "2", kakaoId = "2")
 	@Sql("group-invitationAccept2.sql")
 	@Test
 	void invitationAccept2() throws Exception {
@@ -228,7 +228,7 @@ public class GroupControllerTest {
 	}
 
 	@DisplayName("그룹 초대장 확인 실패(초대장 미갱신)")
-	@WithMockCustomAdminUser(username = "dksgkswn", userId = "2", kakaoId = "2")
+	@WithMockCustomMemberUser(username = "dksgkswn", userId = "2", kakaoId = "2")
 	@Sql("group-invitationCheck4.sql")
 	@Test
 	void invitationCheck4() throws Exception {

--- a/src/test/java/com/example/team1_be/utils/security/AuthenticationConfigTest.java
+++ b/src/test/java/com/example/team1_be/utils/security/AuthenticationConfigTest.java
@@ -1,6 +1,10 @@
 package com.example.team1_be.utils.security;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,5 +40,16 @@ class AuthenticationConfigTest {
 		ResultActions perform = mvc.perform(post("/group/invitation")
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(request));
+	}
+
+	@DisplayName("접근인가 거부시 response entity를 반환할 수 있다.")
+	@WithMockCustomMemberUser
+	@Test
+	void recommendSchedule1() throws Exception {
+		LocalDate date = LocalDate.parse("2023-10-09");
+		ResultActions perform = mvc.perform(
+			get(String.format("/schedule/recommend/%s", date)));
+		perform.andExpect(status().isUnauthorized());
+		perform.andDo(print());
 	}
 }


### PR DESCRIPTION
# 변경 사항 요약

인증/인가에 대한 Security 단에서의 엔트리포인트 구현

## 변경 사항 상세내역

컨트롤러 단위에서 발생하는 에러가 아닌 경우 별도의 에러를 처리해줘야 한다.
Security에서도 인증과 인가에 대한 에러가 발생하는데 컨트롤러와 달리 상태코드만 반환하기 때문에 프론트에서 별도의 응답을 확인하지 못할때가 있다. 그러므로 별도의 엔트리 포인트를 구현하여 이를 처리하고자 했다.

## 사용 방법

컨트롤러에 부여된 인증/인가에 대한 설정에 어긋나는 요청시 해당 엔트리 포인트로 접근됨

## 관련 이슈

close #233 

## 테스트 계획 및 결과

- 인증/인가에 대한 엔트리 포인트 접근과 responseBody 테스트

## 부가 정보 및 주의사항

기본적인 인증과 인가는 Security단에서 이루어지므로 컨트롤러 단에서 응답형태가 달라지면
수정할때 고려해야할 접근지점이 늘어남

# PR 체크리스트
아래 요구사항을 만족하는 지 확인해주세요:

- [x] 요청 직전에 weekly 브랜치의 최신 상태가 반영되었는가
- [x] 실행시 에러가 발생하지 않는가
- [x] 변경 사항에 대한 테스트 코드가 추가되었는가 (버그 수정 / 기능 추가)
- [ ] 문서 업데이트 작업이 수행되었는가 (버그 수정 / 기능 추가)

# PR 유형
본 PR은 어떠한 변화를 가져오나요?

<!-- "x" 로 해당하는 항목을 선택하세요. -->

- [x] 버그 수정
- [x] 신규 기능 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 스타일 업데이트 (형식화, 로컬 변수)
- [ ] 빌드 관련 변화 
- [ ] 환경설정 관련 변화 
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타... 설명해주세요: